### PR TITLE
ESUI-966. Enforce device limits for EEBUS setup

### DIFF
--- a/translations/consolinno-energy.de.ts
+++ b/translations/consolinno-energy.de.ts
@@ -1137,6 +1137,17 @@
     </message>
 </context>
 <context>
+    <name>CoParamDelegate</name>
+    <message>
+        <source>Choose %1</source>
+        <translation>%1 auswählen</translation>
+    </message>
+    <message>
+        <source>Filter %1</source>
+        <translation>%1 durchsuchen</translation>
+    </message>
+</context>
+<context>
     <name>ConEMSState</name>
     <message>
         <source>ConEMS State</source>
@@ -4841,6 +4852,18 @@ Die Preisgrenze ist solange gültig, auch nach ab und wieder anstecken, bis eine
     <message>
         <source>An error occurred while setting up the EEBUS device. Please try again.</source>
         <translation>Beim Einrichten des EEBUS-Geräts ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.</translation>
+    </message>
+    <message>
+        <source>At the moment, %1 can only control one EV charger. The newly added EEBUS device has been removed again. Support for multiple EV chargers is planned for future releases.</source>
+        <translation>Derzeit kann %1 nur eine EV-Ladestation steuern. Das neu hinzugefügte EEBUS-Gerät wurde wieder entfernt. Die Unterstützung für mehrere EV-Ladestationen ist für zukünftige Versionen geplant.</translation>
+    </message>
+    <message>
+        <source>At the moment, %1 can only control one heatpump. The newly added EEBUS device has been removed again. Support for multiple heatpumps is planned for future releases.</source>
+        <translation>Derzeit kann %1 nur eine Wärmepumpe steuern. Das neu hinzugefügte EEBUS-Gerät wurde wieder entfernt. Die Unterstützung für mehrere Wärmepumpen ist für zukünftige Versionen geplant.</translation>
+    </message>
+    <message>
+        <source>%1 The newly added EEBUS device could not be removed automatically.</source>
+        <translation>%1 Das neu hinzugefügte EEBUS-Gerät konnte nicht automatisch entfernt werden.</translation>
     </message>
 </context>
 <context>

--- a/translations/consolinno-energy.de.ts
+++ b/translations/consolinno-energy.de.ts
@@ -4854,16 +4854,20 @@ Die Preisgrenze ist solange gültig, auch nach ab und wieder anstecken, bis eine
         <translation>Beim Einrichten des EEBUS-Geräts ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <source>At the moment, %1 can only control one EV charger. The newly added EEBUS device has been removed again. Support for multiple EV chargers is planned for future releases.</source>
-        <translation>Derzeit kann %1 nur eine EV-Ladestation steuern. Das neu hinzugefügte EEBUS-Gerät wurde wieder entfernt. Die Unterstützung für mehrere EV-Ladestationen ist für zukünftige Versionen geplant.</translation>
+        <source>At the moment, %1 can only control one EV charger. Support for multiple EV chargers is planned for future releases.</source>
+        <translation>Derzeit kann %1 nur eine EV-Ladestation steuern. Die Unterstützung für mehrere EV-Ladestationen ist für zukünftige Versionen geplant.</translation>
     </message>
     <message>
-        <source>At the moment, %1 can only control one heatpump. The newly added EEBUS device has been removed again. Support for multiple heatpumps is planned for future releases.</source>
-        <translation>Derzeit kann %1 nur eine Wärmepumpe steuern. Das neu hinzugefügte EEBUS-Gerät wurde wieder entfernt. Die Unterstützung für mehrere Wärmepumpen ist für zukünftige Versionen geplant.</translation>
+        <source>At the moment, %1 can only control one heat pump. Support for multiple heat pumps is planned for future releases.</source>
+        <translation>Derzeit kann %1 nur eine Wärmepumpe steuern. Die Unterstützung für mehrere Wärmepumpen ist für zukünftige Versionen geplant.</translation>
     </message>
     <message>
-        <source>%1 The newly added EEBUS device could not be removed automatically.</source>
-        <translation>%1 Das neu hinzugefügte EEBUS-Gerät konnte nicht automatisch entfernt werden.</translation>
+        <source>%1 The newly added EEBUS device has been removed again.</source>
+        <translation>%1 Das neu hinzugefügte EEBUS-Gerät wurde wieder entfernt.</translation>
+    </message>
+    <message>
+        <source>%1 The newly added EEBUS device could not be removed automatically. Please remove it manually.</source>
+        <translation>%1 Das neu hinzugefügte EEBUS-Gerät konnte nicht automatisch entfernt werden. Bitte entfernen Sie es manuell.</translation>
     </message>
 </context>
 <context>

--- a/translations/consolinno-energy.en.ts
+++ b/translations/consolinno-energy.en.ts
@@ -4833,15 +4833,19 @@ Would you like to continue anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>At the moment, %1 can only control one EV charger. The newly added EEBUS device has been removed again. Support for multiple EV chargers is planned for future releases.</source>
+        <source>At the moment, %1 can only control one EV charger. Support for multiple EV chargers is planned for future releases.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>At the moment, %1 can only control one heatpump. The newly added EEBUS device has been removed again. Support for multiple heatpumps is planned for future releases.</source>
+        <source>At the moment, %1 can only control one heat pump. Support for multiple heat pumps is planned for future releases.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 The newly added EEBUS device could not be removed automatically.</source>
+        <source>%1 The newly added EEBUS device has been removed again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 The newly added EEBUS device could not be removed automatically. Please remove it manually.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/consolinno-energy.en.ts
+++ b/translations/consolinno-energy.en.ts
@@ -1128,6 +1128,17 @@
     </message>
 </context>
 <context>
+    <name>CoParamDelegate</name>
+    <message>
+        <source>Choose %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ConEMSState</name>
     <message>
         <source>ConEMS State</source>
@@ -4819,6 +4830,18 @@ Would you like to continue anyway?</source>
     </message>
     <message>
         <source>An error occurred while setting up the EEBUS device. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At the moment, %1 can only control one EV charger. The newly added EEBUS device has been removed again. Support for multiple EV chargers is planned for future releases.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>At the moment, %1 can only control one heatpump. The newly added EEBUS device has been removed again. Support for multiple heatpumps is planned for future releases.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 The newly added EEBUS device could not be removed automatically.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/wizards/SetupEEBUSWizard.qml
+++ b/wizards/SetupEEBUSWizard.qml
@@ -63,10 +63,15 @@ Page {
 
             var thingId = thing.id.toString();
             var matchesPendingGateway = d.pendingGatewayThingId !== "" && thing.parentId.toString() === d.pendingGatewayThingId;
-            var isNewThing = d.knownEebusChildThingIds.indexOf(thingId) === -1;
-
-            if (!matchesPendingGateway && !isNewThing) {
-                continue;
+            if (d.pendingGatewayThingId !== "") {
+                if (!matchesPendingGateway) {
+                    continue;
+                }
+            } else {
+                var isNewThing = d.knownEebusChildThingIds.indexOf(thingId) === -1;
+                if (!isNewThing) {
+                    continue;
+                }
             }
 
             if (root.deviceTypeForThing(thing) !== "") {
@@ -234,7 +239,7 @@ Page {
                 return;
             }
 
-            if (thing.parentId.toString() !== d.pendingGatewayThingId && root.eebusChildThingClassIds.indexOf(thing.thingClassId.toString()) === -1) {
+            if (thing.parentId.toString() !== d.pendingGatewayThingId || root.eebusChildThingClassIds.indexOf(thing.thingClassId.toString()) === -1) {
                 return;
             }
 

--- a/wizards/SetupEEBUSWizard.qml
+++ b/wizards/SetupEEBUSWizard.qml
@@ -19,8 +19,8 @@ Page {
         "7c29d23d-d98b-46fd-b941-39a585159fbe",  // EEBus Inverter
         "f84f7c28-04cc-4da5-8564-402a9361b136"   // EEBus GridGuard
     ]
-    readonly property string evChargerLimitExceededText: qsTr("At the moment, %1 can only control one EV charger. The newly added EEBUS device has been removed again. Support for multiple EV chargers is planned for future releases.").arg(Configuration.deviceName)
-    readonly property string heatPumpLimitExceededText: qsTr("At the moment, %1 can only control one heatpump. The newly added EEBUS device has been removed again. Support for multiple heatpumps is planned for future releases.").arg(Configuration.deviceName)
+    readonly property string evChargerLimitExceededText: qsTr("At the moment, %1 can only control one EV charger. Support for multiple EV chargers is planned for future releases.").arg(Configuration.deviceName)
+    readonly property string heatPumpLimitExceededText: qsTr("At the moment, %1 can only control one heat pump. Support for multiple heat pumps is planned for future releases.").arg(Configuration.deviceName)
 
     function currentEebusChildThingIds() {
         var thingIds = [];
@@ -106,6 +106,14 @@ Page {
         default:
             return "";
         }
+    }
+
+    function limitExceededResultText(baseText, removalSucceeded) {
+        if (removalSucceeded) {
+            return qsTr("%1 The newly added EEBUS device has been removed again.").arg(baseText);
+        }
+
+        return qsTr("%1 The newly added EEBUS device could not be removed automatically. Please remove it manually.").arg(baseText);
     }
 
     signal done(bool skip, bool abort, bool back)
@@ -254,14 +262,14 @@ Page {
             busyOverlay.shown = false;
 
             if (thingError === Thing.ThingErrorNoError) {
-                d.showSetupResult(Thing.ThingErrorSetupFailed, null, d.pendingLimitExceededMessage);
+                d.showSetupResult(Thing.ThingErrorSetupFailed, null, root.limitExceededResultText(d.pendingLimitExceededMessage, true));
                 return;
             }
 
             d.showSetupResult(
                 Thing.ThingErrorSetupFailed,
                 null,
-                qsTr("%1 The newly added EEBUS device could not be removed automatically.").arg(d.pendingLimitExceededMessage)
+                root.limitExceededResultText(d.pendingLimitExceededMessage, false)
             );
         }
     }

--- a/wizards/SetupEEBUSWizard.qml
+++ b/wizards/SetupEEBUSWizard.qml
@@ -19,6 +19,89 @@ Page {
         "7c29d23d-d98b-46fd-b941-39a585159fbe",  // EEBus Inverter
         "f84f7c28-04cc-4da5-8564-402a9361b136"   // EEBus GridGuard
     ]
+    readonly property string evChargerLimitExceededText: qsTr("At the moment, %1 can only control one EV charger. The newly added EEBUS device has been removed again. Support for multiple EV chargers is planned for future releases.").arg(Configuration.deviceName)
+    readonly property string heatPumpLimitExceededText: qsTr("At the moment, %1 can only control one heatpump. The newly added EEBUS device has been removed again. Support for multiple heatpumps is planned for future releases.").arg(Configuration.deviceName)
+
+    function currentEebusChildThingIds() {
+        var thingIds = [];
+        for (var i = 0; i < eebusChildThingsProxy.count; i++) {
+            var thing = eebusChildThingsProxy.get(i);
+            if (thing) {
+                thingIds.push(thing.id.toString());
+            }
+        }
+        return thingIds;
+    }
+
+    function deviceTypeForThing(thing) {
+        if (!thing || !thing.thingClass) {
+            return "";
+        }
+
+        var interfaces = thing.thingClass.interfaces;
+        if (interfaces.indexOf("evcharger") !== -1) {
+            return "evcharger";
+        }
+        if (interfaces.indexOf("heatpump") !== -1 || interfaces.indexOf("smartgridheatpump") !== -1 || interfaces.indexOf("simpleheatpump") !== -1 || interfaces.indexOf("pvsurplusheatpump") !== -1) {
+            return "heatpump";
+        }
+        if (interfaces.indexOf("solarinverter") !== -1) {
+            return "solarinverter";
+        }
+
+        return "";
+    }
+
+    function findNewEebusChildThing() {
+        var fallbackThing = null;
+
+        for (var i = 0; i < eebusChildThingsProxy.count; i++) {
+            var thing = eebusChildThingsProxy.get(i);
+            if (!thing) {
+                continue;
+            }
+
+            var thingId = thing.id.toString();
+            var matchesPendingGateway = d.pendingGatewayThingId !== "" && thing.parentId.toString() === d.pendingGatewayThingId;
+            var isNewThing = d.knownEebusChildThingIds.indexOf(thingId) === -1;
+
+            if (!matchesPendingGateway && !isNewThing) {
+                continue;
+            }
+
+            if (root.deviceTypeForThing(thing) !== "") {
+                return thing;
+            }
+
+            if (!fallbackThing) {
+                fallbackThing = thing;
+            }
+        }
+
+        return fallbackThing;
+    }
+
+    function isDeviceLimitExceeded(thing) {
+        switch (root.deviceTypeForThing(thing)) {
+        case "evcharger":
+            return evChargerThingsProxy.count > 1;
+        case "heatpump":
+            return heatPumpThingsProxy.count > 1;
+        default:
+            return false;
+        }
+    }
+
+    function limitExceededTextForThing(thing) {
+        switch (root.deviceTypeForThing(thing)) {
+        case "evcharger":
+            return root.evChargerLimitExceededText;
+        case "heatpump":
+            return root.heatPumpLimitExceededText;
+        default:
+            return "";
+        }
+    }
 
     signal done(bool skip, bool abort, bool back)
 
@@ -35,6 +118,44 @@ Page {
         property string thingName: ""
         property var params: []
         property string name: ""
+        property var knownEebusChildThingIds: []
+        property string pendingGatewayThingId: ""
+        property string pendingAddMessage: ""
+        property string pendingLimitExceededMessage: ""
+        property int pendingRemoveCommandId: -1
+
+        function resetPendingSetup() {
+            pendingThingTimer.stop();
+            pendingThingTimer.retryCount = 0;
+            d.pendingGatewayThingId = "";
+            d.pendingAddMessage = "";
+            d.pendingLimitExceededMessage = "";
+            d.pendingRemoveCommandId = -1;
+        }
+
+        function showSetupResult(thingError, thing, message) {
+            d.resetPendingSetup();
+            pageStack.push(setupResultComponent, {thingError: thingError, thing: thing, message: message});
+        }
+
+        function handleAddedEebusThing(thing) {
+            if (!thing || d.pendingRemoveCommandId !== -1) {
+                return false;
+            }
+
+            pendingThingTimer.stop();
+            pendingThingTimer.retryCount = 0;
+
+            if (!root.isDeviceLimitExceeded(thing)) {
+                d.showSetupResult(Thing.ThingErrorNoError, thing, d.pendingAddMessage);
+                return true;
+            }
+
+            d.pendingLimitExceededMessage = root.limitExceededTextForThing(thing);
+            busyOverlay.shown = true;
+            d.pendingRemoveCommandId = engine.thingManager.removeThing(thing.isChild ? thing.parentId : thing.id);
+            return true;
+        }
     }
 
     ThingDiscovery {
@@ -49,9 +170,43 @@ Page {
         shownThingClassIds: root.eebusChildThingClassIds
     }
 
+    ThingsProxy {
+        id: evChargerThingsProxy
+        engine: _engine
+        shownInterfaces: ["evcharger"]
+    }
+
+    ThingsProxy {
+        id: heatPumpThingsProxy
+        engine: _engine
+        shownInterfaces: ["heatpump", "smartgridheatpump", "simpleheatpump", "pvsurplusheatpump"]
+    }
+
     StackView {
         id: internalPageStack
         anchors.fill: parent
+    }
+
+    Timer {
+        id: pendingThingTimer
+        interval: 200
+        repeat: true
+        running: false
+
+        property int retryCount: 0
+
+        onTriggered: {
+            var newThing = root.findNewEebusChildThing();
+            if (d.handleAddedEebusThing(newThing)) {
+                return;
+            }
+
+            retryCount += 1;
+            if (retryCount >= 20) {
+                var gatewayThing = d.pendingGatewayThingId !== "" ? engine.thingManager.things.getThing(d.pendingGatewayThingId) : null;
+                d.showSetupResult(Thing.ThingErrorNoError, gatewayThing, d.pendingAddMessage);
+            }
+        }
     }
 
     Connections {
@@ -59,8 +214,50 @@ Page {
 
         onAddThingReply: function(commandId, thingError, thingId, displayMessage) {
             busyOverlay.shown = false;
-            var thing = engine.thingManager.things.getThing(thingId);
-            pageStack.push(setupResultComponent, {thingError: thingError, thing: thing, message: displayMessage});
+            if (thingError !== Thing.ThingErrorNoError) {
+                var thing = engine.thingManager.things.getThing(thingId);
+                d.showSetupResult(thingError, thing, displayMessage);
+                return;
+            }
+
+            d.pendingGatewayThingId = thingId.toString();
+            d.pendingAddMessage = displayMessage;
+
+            if (!d.handleAddedEebusThing(root.findNewEebusChildThing())) {
+                pendingThingTimer.retryCount = 0;
+                pendingThingTimer.start();
+            }
+        }
+
+        onThingAdded: function(thing) {
+            if (d.pendingGatewayThingId === "" || !thing) {
+                return;
+            }
+
+            if (thing.parentId.toString() !== d.pendingGatewayThingId && root.eebusChildThingClassIds.indexOf(thing.thingClassId.toString()) === -1) {
+                return;
+            }
+
+            d.handleAddedEebusThing(root.findNewEebusChildThing());
+        }
+
+        onRemoveThingReply: function(commandId, thingError, ruleIds) {
+            if (commandId !== d.pendingRemoveCommandId) {
+                return;
+            }
+
+            busyOverlay.shown = false;
+
+            if (thingError === Thing.ThingErrorNoError) {
+                d.showSetupResult(Thing.ThingErrorSetupFailed, null, d.pendingLimitExceededMessage);
+                return;
+            }
+
+            d.showSetupResult(
+                Thing.ThingErrorSetupFailed,
+                null,
+                qsTr("%1 The newly added EEBUS device could not be removed automatically.").arg(d.pendingLimitExceededMessage)
+            );
         }
     }
 
@@ -346,6 +543,8 @@ Page {
                     }
                     d.params = params;
                     d.name = nameTextField.text;
+                    d.resetPendingSetup();
+                    d.knownEebusChildThingIds = root.currentEebusChildThingIds();
 
                     if (d.thingDescriptor) {
                         engine.thingManager.addDiscoveredThing(thingClass.id, d.thingDescriptor.id, d.name, params);
@@ -417,7 +616,7 @@ Page {
                     Layout.fillWidth: true
                     Layout.margins: Style.margins
                     wrapMode: Text.WordWrap
-                    text: qsTr("An error occurred while setting up the EEBUS device. Please try again.")
+                    text: setupResultPage.message !== "" ? setupResultPage.message : qsTr("An error occurred while setting up the EEBUS device. Please try again.")
                     visible: setupResultPage.thingError != Thing.ThingErrorNoError
                 }
 


### PR DESCRIPTION
Handle EEBUS child thing creation by checking the detected device type after setup and removing newly added gateways again when EV charger or heat pump limits would be exceeded.
