### PR TITLE
ESUI-1245: Adopt PvSurplusEntries type and lock support for pvSurplusPriolist

### DIFF
--- a/components/CoSortableCard.qml
+++ b/components/CoSortableCard.qml
@@ -5,6 +5,7 @@ import Nymea 1.0
 import "../components"
 
 Item {
+    id: root
     property alias text: card.text
     property alias helpText: card.helpText
     property alias labelText: card.labelText
@@ -13,6 +14,7 @@ Item {
     property alias iconRight: card.iconRight
     property alias card: card
     property bool dragging: false
+    property bool locked: false
 
     readonly property real dragHandleStartX: width - 2 * Style.margins - dragHandleIcon.width
 
@@ -51,7 +53,9 @@ Item {
 
         ColorIcon {
             id: dragHandleIcon
-            name: Qt.resolvedUrl("qrc:/icons/drag_handle.svg")
+            name: root.locked ?
+                      Qt.resolvedUrl("qrc:/icons/lock.svg") :
+                      Qt.resolvedUrl("qrc:/icons/drag_handle.svg")
             color: Style.colors.brand_Basic_Icon
             Layout.alignment:  Qt.AlignVCenter
             size: 24

--- a/devicepages/HeatingElementDevicePage.qml
+++ b/devicepages/HeatingElementDevicePage.qml
@@ -188,7 +188,7 @@ GenericConfigPage {
                             id: pvPrioCard
                             Layout.fillWidth: true
                             labelText: qsTr("Priority")
-                            text: (hemsManager.emsConfiguration.pvSurplusPriolist.indexOf(root.thing.id) + 1).toString()
+                            text: (hemsManager.emsConfiguration.pvSurplusPriolistIndexOf(root.thing.id) + 1).toString()
                             showChildrenIndicator: true
 
                             onClicked: {

--- a/devicepages/SwitchableConsumerDevicePage.qml
+++ b/devicepages/SwitchableConsumerDevicePage.qml
@@ -200,7 +200,7 @@ GenericConfigPage {
                             id: pvPrioCard
                             Layout.fillWidth: true
                             labelText: qsTr("Priority")
-                            text: (hemsManager.emsConfiguration.pvSurplusPriolist.indexOf(root.thing.id) + 1).toString()
+                            text: (hemsManager.emsConfiguration.pvSurplusPriolistIndexOf(root.thing.id) + 1).toString()
                             showChildrenIndicator: true
 
                             onClicked: {

--- a/icons/lock.svg
+++ b/icons/lock.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g>
+  <path d="M9 11V7A3 3 0 0 1 15 7V11" stroke="#808080" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="6.5" y="10.5" width="11" height="10" rx="2" stroke="#808080" stroke-width="2.2"/>
+  <circle cx="12" cy="16" r="1.5" fill="#808080"/>
+</g>
+</svg>

--- a/optimization/BatteryConfigView.qml
+++ b/optimization/BatteryConfigView.qml
@@ -221,7 +221,7 @@ GenericConfigPage {
                             id: pvPrioCard
                             Layout.fillWidth: true
                             labelText: qsTr("Priority")
-                            text: (hemsManager.emsConfiguration.pvSurplusPriolist.indexOf(root.thing.id) + 1).toString()
+                            text: (hemsManager.emsConfiguration.pvSurplusPriolistIndexOf(root.thing.id) + 1).toString()
                             showChildrenIndicator: true
 
                             onClicked: {

--- a/optimization/ChargingConfigView.qml
+++ b/optimization/ChargingConfigView.qml
@@ -1080,7 +1080,7 @@ GenericConfigPage {
                                 id: pvPrioCard
                                 Layout.fillWidth: true
                                 labelText: qsTr("Priority")
-                                text: (hemsManager.emsConfiguration.pvSurplusPriolist.indexOf(root.thing.id) + 1).toString()
+                                text: (hemsManager.emsConfiguration.pvSurplusPriolistIndexOf(root.thing.id) + 1).toString()
                                 showChildrenIndicator: true
                                 visible: isAnyOfModesSelected([pv_excess, simple_pv_excess, dyn_pricing])
 

--- a/optimization/HeatingConfigView.qml
+++ b/optimization/HeatingConfigView.qml
@@ -327,7 +327,7 @@ GenericConfigPage {
                             id: pvPrioCard
                             Layout.fillWidth: true
                             labelText: qsTr("Priority")
-                            text: (hemsManager.emsConfiguration.pvSurplusPriolist.indexOf(root.thing.id) + 1).toString()
+                            text: (hemsManager.emsConfiguration.pvSurplusPriolistIndexOf(root.thing.id) + 1).toString()
                             showChildrenIndicator: true
 
                             onClicked: {

--- a/optimization/PVPriorities.qml
+++ b/optimization/PVPriorities.qml
@@ -116,7 +116,7 @@ Page {
             var thing = engine.thingManager.things.getThing(thingId);
             prioListModel.append({
                 "name": thing ? thing.name : thingId.toString(),
-                "thingId": thing ? "" + thing.id : "",
+                "thingId": thing ? "" + thing.id : "" + thingId,
                 "locked": locked,
                 "icon": thing ? root.thingToIcon(thing) : Qt.resolvedUrl("qrc:/icons/select-none.svg"),
                 "optimizationEnabled": thing ? root.thingOptimizationEnabled(thing) : false

--- a/optimization/PVPriorities.qml
+++ b/optimization/PVPriorities.qml
@@ -33,8 +33,8 @@ Page {
         // model order (which ListModel doesn't track reactively) are re-evaluated.
         property int modelRevision: 0
         property var firstBattery: {
-            for (var i = 0; i < hemsManager.emsConfiguration.pvSurplusPriolist.length; i++) {
-                var thing = engine.thingManager.things.getThing(hemsManager.emsConfiguration.pvSurplusPriolist[i]);
+            for (var i = 0; i < hemsManager.emsConfiguration.pvSurplusPriolist.count; i++) {
+                var thing = engine.thingManager.things.getThing(hemsManager.emsConfiguration.pvSurplusPriolist.get(i).thingId);
                 if (thing && thing.thingClass.interfaces.indexOf("battery") >= 0) {
                     return thing;
                 }
@@ -109,16 +109,15 @@ Page {
 
     function populateFromPrioList(prioList) {
         prioListModel.clear();
-        for (var i = 0; i < prioList.length; i++) {
-            var thingId = prioList[i];
+        for (var i = 0; i < prioList.count; i++) {
+            var entry = prioList.get(i);
+            var thingId = entry.thingId;
+            var locked = entry.locked !== undefined ? entry.locked : false;
             var thing = engine.thingManager.things.getThing(thingId);
             prioListModel.append({
                 "name": thing ? thing.name : thingId.toString(),
-                // QML ListModel cannot store C++ QUuid/ThingId objects — they come back
-                // as undefined on retrieval. Coercing with "" + thing.id forces a plain
-                // JS string, which ListModel preserves and Qt auto-converts back to QUuid
-                // when passed to setPVSurplusPriolist(QList<QUuid>).
                 "thingId": thing ? "" + thing.id : "",
+                "locked": locked,
                 "icon": thing ? root.thingToIcon(thing) : Qt.resolvedUrl("qrc:/icons/select-none.svg"),
                 "optimizationEnabled": thing ? root.thingOptimizationEnabled(thing) : false
             });
@@ -213,6 +212,7 @@ Page {
                                 width: priorityListView.width
                                 text: model.name
                                 iconLeft: model.icon
+                                locked: model.locked
                                 visible: index !== priorityListView.draggingIndex
                                 card.opacity: (model.optimizationEnabled ||
                                                (root.alwaysEnabledThingId !== "" &&
@@ -233,7 +233,12 @@ Page {
                                         mouse.accepted = false;
                                         return;
                                     }
-                                    priorityListView.draggingIndex = priorityListView.indexAt(mouseX, mouseYInList);
+                                    var idx = priorityListView.indexAt(mouseX, mouseYInList);
+                                    if (prioListModel.get(idx).locked) {
+                                        mouse.accepted = false;
+                                        return;
+                                    }
+                                    priorityListView.draggingIndex = idx;
                                     dndItem.text = prioListModel.get(priorityListView.draggingIndex).name;
                                     dndItem.iconLeft = prioListModel.get(priorityListView.draggingIndex).icon;
                                     dndItem.card.opacity = (prioListModel.get(priorityListView.draggingIndex).optimizationEnabled ||
@@ -298,9 +303,9 @@ Page {
                 d.modelRevision;
                 // Enabled only when the current list order differs from the saved pvSurplusPriolist.
                 var prioList = hemsManager.emsConfiguration.pvSurplusPriolist;
-                if (prioListModel.count !== prioList.length) { return true; }
+                if (prioListModel.count !== prioList.count) { return true; }
                 for (var i = 0; i < prioListModel.count; i++) {
-                    if (prioListModel.get(i).thingId !== "" + engine.thingManager.things.getThing(prioList[i]).id) {
+                    if (prioListModel.get(i).thingId !== "" + engine.thingManager.things.getThing(prioList.get(i).thingId).id) {
                         return true;
                     }
                 }
@@ -308,11 +313,11 @@ Page {
             }
 
             onClicked: {
-                var uuidList = [];
+                var entryList = [];
                 for (var i = 0; i < prioListModel.count; i++) {
-                    uuidList.push(prioListModel.get(i).thingId);
+                    entryList.push({"thingId": prioListModel.get(i).thingId, "locked": prioListModel.get(i).locked});
                 }
-                d.pendingCallId = hemsManager.setPVSurplusPriolist(uuidList);
+                d.pendingCallId = hemsManager.setPVSurplusPriolist(entryList);
             }
         }
     }

--- a/optimization/PVPriorities.qml
+++ b/optimization/PVPriorities.qml
@@ -234,7 +234,7 @@ Page {
                                         return;
                                     }
                                     var idx = priorityListView.indexAt(mouseX, mouseYInList);
-                                    if (prioListModel.get(idx).locked) {
+                                    if (idx < 0 || prioListModel.get(idx).locked) {
                                         mouse.accepted = false;
                                         return;
                                     }

--- a/overlay.qrc
+++ b/overlay.qrc
@@ -80,6 +80,7 @@
         <file>icons/dishwasher.svg</file>
         <file>icons/download.svg</file>
         <file>icons/drag_handle.svg</file>
+        <file>icons/lock.svg</file>
         <file>icons/eco.svg</file>
         <file>icons/edit.svg</file>
         <file>icons/electric_bolt.svg</file>

--- a/src/Configurations/emsconfiguration.cpp
+++ b/src/Configurations/emsconfiguration.cpp
@@ -5,28 +5,37 @@ EmsConfiguration::EmsConfiguration(QObject *parent): QObject(parent)
 
 }
 
-QList<QUuid> EmsConfiguration::pvSurplusPriolist() const
+PvSurplusEntries EmsConfiguration::pvSurplusPriolist() const
 {
     return m_pvSurplusPriolist;
 }
 
-void EmsConfiguration::setPvSurplusPriolist(const QList<QUuid> &pvSurplusPriolist)
+void EmsConfiguration::setPvSurplusPriolist(const PvSurplusEntries &pvSurplusPriolist)
 {
     if (m_pvSurplusPriolist == pvSurplusPriolist) { return; }
     m_pvSurplusPriolist = pvSurplusPriolist;
     emit pvSurplusPriolistChanged();
 }
 
-QList<QUuid> EmsConfiguration::defaultPvSurplusPriolist() const
+PvSurplusEntries EmsConfiguration::defaultPvSurplusPriolist() const
 {
     return m_defaultPvSurplusPriolist;
 }
 
-void EmsConfiguration::setDefaultPvSurplusPriolist(const QList<QUuid> &defaultPvSurplusPriolist)
+void EmsConfiguration::setDefaultPvSurplusPriolist(const PvSurplusEntries &defaultPvSurplusPriolist)
 {
     if (m_defaultPvSurplusPriolist == defaultPvSurplusPriolist) { return; }
     m_defaultPvSurplusPriolist = defaultPvSurplusPriolist;
     emit defaultPvSurplusPriolistChanged();
+}
+
+int EmsConfiguration::pvSurplusPriolistIndexOf(const QUuid &thingId) const
+{
+    for (int i = 0; i < m_pvSurplusPriolist.size(); ++i) {
+        if (m_pvSurplusPriolist.at(i).thingId() == thingId)
+            return i;
+    }
+    return -1;
 }
 
 QList<QUuid> EmsConfiguration::limitPriolist() const

--- a/src/Configurations/emsconfiguration.h
+++ b/src/Configurations/emsconfiguration.h
@@ -6,11 +6,13 @@
 #include <QObject>
 #include <QUuid>
 
+#include "pvsurplusprioentry.h"
+
 class EmsConfiguration : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QList<QUuid> pvSurplusPriolist READ pvSurplusPriolist WRITE setPvSurplusPriolist NOTIFY pvSurplusPriolistChanged)
-    Q_PROPERTY(QList<QUuid> defaultPvSurplusPriolist READ defaultPvSurplusPriolist WRITE setDefaultPvSurplusPriolist NOTIFY defaultPvSurplusPriolistChanged)
+    Q_PROPERTY(PvSurplusEntries pvSurplusPriolist READ pvSurplusPriolist WRITE setPvSurplusPriolist NOTIFY pvSurplusPriolistChanged)
+    Q_PROPERTY(PvSurplusEntries defaultPvSurplusPriolist READ defaultPvSurplusPriolist WRITE setDefaultPvSurplusPriolist NOTIFY defaultPvSurplusPriolistChanged)
     Q_PROPERTY(QList<QUuid> limitPriolist READ limitPriolist WRITE setLimitPriolist NOTIFY limitPriolistChanged)
     Q_PROPERTY(QList<QUuid> defaultLimitPriolist READ defaultLimitPriolist WRITE setDefaultLimitPriolist NOTIFY defaultLimitPriolistChanged)
 
@@ -18,14 +20,16 @@ public:
     explicit EmsConfiguration(QObject *parent = nullptr);
 
     // Priority list for PV surplus distribution
-    QList<QUuid> pvSurplusPriolist() const;
-    void setPvSurplusPriolist(const QList<QUuid> &pvSurplusPriolist);
+    PvSurplusEntries pvSurplusPriolist() const;
+    void setPvSurplusPriolist(const PvSurplusEntries &pvSurplusPriolist);
 
     // Default priority list for PV surplus distribution
-    QList<QUuid> defaultPvSurplusPriolist() const;
-    void setDefaultPvSurplusPriolist(const QList<QUuid> &defaultPvSurplusPriolist);
+    PvSurplusEntries defaultPvSurplusPriolist() const;
+    void setDefaultPvSurplusPriolist(const PvSurplusEntries &defaultPvSurplusPriolist);
 
     // Priority list for load limiting / curtailment
+    Q_INVOKABLE int pvSurplusPriolistIndexOf(const QUuid &thingId) const;
+
     QList<QUuid> limitPriolist() const;
     void setLimitPriolist(const QList<QUuid> &limitPriolist);
 
@@ -40,8 +44,8 @@ signals:
     void defaultLimitPriolistChanged();
 
 private:
-    QList<QUuid> m_pvSurplusPriolist;
-    QList<QUuid> m_defaultPvSurplusPriolist;
+    PvSurplusEntries m_pvSurplusPriolist;
+    PvSurplusEntries m_defaultPvSurplusPriolist;
     QList<QUuid> m_limitPriolist;
     QList<QUuid> m_defaultLimitPriolist;
 };

--- a/src/Configurations/pvsurplusprioentry.cpp
+++ b/src/Configurations/pvsurplusprioentry.cpp
@@ -36,5 +36,9 @@ bool PvSurplusEntry::operator==(const PvSurplusEntry &other) const
 
 QVariant PvSurplusEntries::get(int index) const
 {
+    if (index < 0 || index >= size()) {
+        return QVariant();
+    }
+
     return QVariant::fromValue(at(index));
 }

--- a/src/Configurations/pvsurplusprioentry.cpp
+++ b/src/Configurations/pvsurplusprioentry.cpp
@@ -1,0 +1,62 @@
+/* Copyright (C) Consolinno Energy GmbH - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+
+#include "pvsurplusprioentry.h"
+
+#include <QVariant>
+
+PvSurplusEntry::PvSurplusEntry() {}
+
+PvSurplusEntry::PvSurplusEntry(const QUuid &thingId, bool locked)
+    : m_thingId(thingId)
+    , m_locked(locked)
+{}
+
+QUuid PvSurplusEntry::thingId() const
+{
+    return m_thingId;
+}
+
+void PvSurplusEntry::setThingId(const QUuid &thingId)
+{
+    m_thingId = thingId;
+}
+
+bool PvSurplusEntry::locked() const
+{
+    return m_locked;
+}
+
+void PvSurplusEntry::setLocked(bool locked)
+{
+    m_locked = locked;
+}
+
+bool PvSurplusEntry::operator==(const PvSurplusEntry &other) const
+{
+    return m_thingId == other.thingId() && m_locked == other.locked();
+}
+
+bool PvSurplusEntry::operator!=(const PvSurplusEntry &other) const
+{
+    return !(*this == other);
+}
+
+QDebug operator<<(QDebug debug, const PvSurplusEntry &entry)
+{
+    debug.nospace() << "PvSurplusEntry(thingId: " << entry.thingId().toString()
+                    << ", locked: " << entry.locked() << ")";
+    return debug.maybeSpace();
+}
+
+QVariant PvSurplusEntries::get(int index) const
+{
+    return QVariant::fromValue(at(index));
+}
+
+void PvSurplusEntries::put(const QVariant &variant)
+{
+    append(variant.value<PvSurplusEntry>());
+}

--- a/src/Configurations/pvsurplusprioentry.cpp
+++ b/src/Configurations/pvsurplusprioentry.cpp
@@ -1,8 +1,3 @@
-/* Copyright (C) Consolinno Energy GmbH - All Rights Reserved
- * Unauthorized copying of this file, via any medium is strictly prohibited
- * Proprietary and confidential
- */
-
 #include "pvsurplusprioentry.h"
 
 #include <QVariant>

--- a/src/Configurations/pvsurplusprioentry.cpp
+++ b/src/Configurations/pvsurplusprioentry.cpp
@@ -39,24 +39,7 @@ bool PvSurplusEntry::operator==(const PvSurplusEntry &other) const
     return m_thingId == other.thingId() && m_locked == other.locked();
 }
 
-bool PvSurplusEntry::operator!=(const PvSurplusEntry &other) const
-{
-    return !(*this == other);
-}
-
-QDebug operator<<(QDebug debug, const PvSurplusEntry &entry)
-{
-    debug.nospace() << "PvSurplusEntry(thingId: " << entry.thingId().toString()
-                    << ", locked: " << entry.locked() << ")";
-    return debug.maybeSpace();
-}
-
 QVariant PvSurplusEntries::get(int index) const
 {
     return QVariant::fromValue(at(index));
-}
-
-void PvSurplusEntries::put(const QVariant &variant)
-{
-    append(variant.value<PvSurplusEntry>());
 }

--- a/src/Configurations/pvsurplusprioentry.h
+++ b/src/Configurations/pvsurplusprioentry.h
@@ -1,8 +1,3 @@
-/* Copyright (C) Consolinno Energy GmbH - All Rights Reserved
- * Unauthorized copying of this file, via any medium is strictly prohibited
- * Proprietary and confidential
- */
-
 #ifndef PVSURPLUSPRIOENTRY_H
 #define PVSURPLUSPRIOENTRY_H
 

--- a/src/Configurations/pvsurplusprioentry.h
+++ b/src/Configurations/pvsurplusprioentry.h
@@ -1,0 +1,56 @@
+/* Copyright (C) Consolinno Energy GmbH - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+
+#ifndef PVSURPLUSPRIOENTRY_H
+#define PVSURPLUSPRIOENTRY_H
+
+#include <QDebug>
+#include <QList>
+#include <QObject>
+#include <QUuid>
+
+class PvSurplusEntry
+{
+    Q_GADGET
+    Q_PROPERTY(QUuid thingId READ thingId WRITE setThingId USER true)
+    Q_PROPERTY(bool locked READ locked WRITE setLocked USER true)
+
+public:
+    PvSurplusEntry();
+    PvSurplusEntry(const QUuid &thingId, bool locked);
+
+    QUuid thingId() const;
+    void setThingId(const QUuid &thingId);
+
+    bool locked() const;
+    void setLocked(bool locked);
+
+    bool operator==(const PvSurplusEntry &other) const;
+    bool operator!=(const PvSurplusEntry &other) const;
+
+private:
+    QUuid m_thingId;
+    bool m_locked = false;
+};
+
+QDebug operator<<(QDebug debug, const PvSurplusEntry &entry);
+
+class PvSurplusEntries : public QList<PvSurplusEntry>
+{
+    Q_GADGET
+    Q_PROPERTY(int count READ count)
+public:
+    PvSurplusEntries() {}
+    PvSurplusEntries(const QList<PvSurplusEntry> &other)
+        : QList<PvSurplusEntry>(other)
+    {}
+    Q_INVOKABLE QVariant get(int index) const;
+    Q_INVOKABLE void put(const QVariant &variant);
+};
+
+Q_DECLARE_METATYPE(PvSurplusEntry)
+Q_DECLARE_METATYPE(PvSurplusEntries)
+
+#endif // PVSURPLUSPRIOENTRY_H

--- a/src/Configurations/pvsurplusprioentry.h
+++ b/src/Configurations/pvsurplusprioentry.h
@@ -6,7 +6,6 @@
 #ifndef PVSURPLUSPRIOENTRY_H
 #define PVSURPLUSPRIOENTRY_H
 
-#include <QDebug>
 #include <QList>
 #include <QObject>
 #include <QUuid>
@@ -28,14 +27,11 @@ public:
     void setLocked(bool locked);
 
     bool operator==(const PvSurplusEntry &other) const;
-    bool operator!=(const PvSurplusEntry &other) const;
 
 private:
     QUuid m_thingId;
     bool m_locked = false;
 };
-
-QDebug operator<<(QDebug debug, const PvSurplusEntry &entry);
 
 class PvSurplusEntries : public QList<PvSurplusEntry>
 {
@@ -47,7 +43,6 @@ public:
         : QList<PvSurplusEntry>(other)
     {}
     Q_INVOKABLE QVariant get(int index) const;
-    Q_INVOKABLE void put(const QVariant &variant);
 };
 
 Q_DECLARE_METATYPE(PvSurplusEntry)

--- a/src/hemsmanager.cpp
+++ b/src/hemsmanager.cpp
@@ -931,25 +931,32 @@ int HemsManager::factoryReset()
     return m_engine->jsonRpcClient()->sendCommand("Hems.FactoryReset", QVariantMap(), this, "factoryResetResponse");
 }
 
-int HemsManager::setPVSurplusPriolist(const QStringList &pvSurplusPriolist)
+int HemsManager::setPVSurplusPriolist(const QVariantList &pvSurplusPriolist)
 {
-    auto toVariantList = [](const QList<QUuid> &uuids) {
+    auto uuidListToVariant = [](const QList<QUuid> &uuids) {
         QVariantList list;
         foreach (const QUuid &uuid, uuids)
             list.append(uuid.toString());
         return list;
     };
 
-    QVariantList uuidList;
-    foreach (const QString &uuid, pvSurplusPriolist)
-        uuidList.append(uuid);
+    auto pvEntriesToVariant = [](const PvSurplusEntries &entries) {
+        QVariantList list;
+        foreach (const PvSurplusEntry &entry, entries) {
+            QVariantMap map;
+            map.insert("thingId", entry.thingId().toString());
+            map.insert("locked", entry.locked());
+            list.append(map);
+        }
+        return list;
+    };
 
     QVariantMap emsConfiguration;
-    emsConfiguration.insert("pvSurplusPriolist", uuidList);
+    emsConfiguration.insert("pvSurplusPriolist", pvSurplusPriolist);
     // Include all other lists unchanged — omitting them would cause the backend to clear them.
-    emsConfiguration.insert("defaultPvSurplusPriolist", toVariantList(m_emsConfiguration->defaultPvSurplusPriolist()));
-    emsConfiguration.insert("limitPriolist", toVariantList(m_emsConfiguration->limitPriolist()));
-    emsConfiguration.insert("defaultLimitPriolist", toVariantList(m_emsConfiguration->defaultLimitPriolist()));
+    emsConfiguration.insert("defaultPvSurplusPriolist", pvEntriesToVariant(m_emsConfiguration->defaultPvSurplusPriolist()));
+    emsConfiguration.insert("limitPriolist", uuidListToVariant(m_emsConfiguration->limitPriolist()));
+    emsConfiguration.insert("defaultLimitPriolist", uuidListToVariant(m_emsConfiguration->defaultLimitPriolist()));
 
     QVariantMap params;
     params.insert("emsConfiguration", emsConfiguration);
@@ -1297,8 +1304,17 @@ void HemsManager::updateEmsConfiguration(const QVariantMap &configurationMap)
         return result;
     };
 
-    m_emsConfiguration->setPvSurplusPriolist(uuidListFromVariant(configurationMap.value("pvSurplusPriolist")));
-    m_emsConfiguration->setDefaultPvSurplusPriolist(uuidListFromVariant(configurationMap.value("defaultPvSurplusPriolist")));
+    auto pvEntriesFromVariant = [](const QVariant &v) {
+        PvSurplusEntries result;
+        foreach (const QVariant &item, v.toList()) {
+            QVariantMap map = item.toMap();
+            result.append(PvSurplusEntry(QUuid(map.value("thingId").toString()), map.value("locked").toBool()));
+        }
+        return result;
+    };
+
+    m_emsConfiguration->setPvSurplusPriolist(pvEntriesFromVariant(configurationMap.value("pvSurplusPriolist")));
+    m_emsConfiguration->setDefaultPvSurplusPriolist(pvEntriesFromVariant(configurationMap.value("defaultPvSurplusPriolist")));
     m_emsConfiguration->setLimitPriolist(uuidListFromVariant(configurationMap.value("limitPriolist")));
     m_emsConfiguration->setDefaultLimitPriolist(uuidListFromVariant(configurationMap.value("defaultLimitPriolist")));
 }

--- a/src/hemsmanager.h
+++ b/src/hemsmanager.h
@@ -115,7 +115,7 @@ public:
     // System operations
     Q_INVOKABLE int factoryReset();
 
-    Q_INVOKABLE int setPVSurplusPriolist(const QStringList &pvSurplusPriolist);
+    Q_INVOKABLE int setPVSurplusPriolist(const QVariantList &pvSurplusPriolist);
 signals:
 
     void engineChanged();


### PR DESCRIPTION
- Add pvsurplusprioentry.h/.cpp (PvSurplusEntry/PvSurplusEntries types)
- Update EmsConfiguration to use PvSurplusEntries for pvSurplusPriolist and defaultPvSurplusPriolist, add pvSurplusPriolistIndexOf() invokable
- Update HemsManager serialization/deserialization for new {thingId, locked} entry format
- Add lock.svg icon
- Update PVPriorities.qml to use PvSurplusEntries API (.count/.get()) and respect locked entries (no drag)
- Update CoSortableCard with locked property (lock icon when locked)
- Replace pvSurplusPriolist.indexOf() with pvSurplusPriolistIndexOf() in device pages and config views