### PR TITLE
ESUI-1285. Fix SIGSEGV when switching selection tabs in stats graphs.

### DIFF
--- a/mainviews/energy/ConsolinnoPowerConsumptionBalanceHistory.qml
+++ b/mainviews/energy/ConsolinnoPowerConsumptionBalanceHistory.qml
@@ -90,7 +90,7 @@ Item {
             acquisitionUpperSeries.removePoints(index, count)
             storageUpperSeries.removePoints(index, count)
             selfProductionUpperSeries.removePoints(index, count)
-            consumptionUpperSeries.removePoints(index, count)
+            // consumptionUpperSeries is never populated (consumptionSeries.insertEntry is disabled)
             zeroSeries.shrink()
         }
     }

--- a/mainviews/energy/ConsolinnoPowerProductionBalanceHistory.qml
+++ b/mainviews/energy/ConsolinnoPowerProductionBalanceHistory.qml
@@ -91,7 +91,7 @@ Item {
             acquisitionUpperSeries.removePoints(index, count)
             storageUpperSeries.removePoints(index, count)
             selfConsumptionUpperSeries.removePoints(index, count)
-            productionUpperSeries.removePoints(index, count)
+            // productionUpperSeries is never populated (productionSeries.insertEntry is disabled)
             zeroSeries.shrink()
         }
     }


### PR DESCRIPTION
removePoints was called on LineSeries that are never populated because their corresponding insertEntry calls are disabled. This caused an out-of-bounds access in QXYSeries::removePoints -> SIGSEGV.