### PR TITLE
ESUI-1297. Restore splash_dark.xml to also clean build artifacts

### DIFF
--- a/restore_generated.sh
+++ b/restore_generated.sh
@@ -14,6 +14,7 @@ packaging/android/build.gradle \
 packaging/android/google-services.json \
 packaging/android/notificationicon.svg \
 packaging/android/res/drawable/splash_light.xml \
+packaging/android/res/drawable/splash_dark.xml \
 packaging/android/splash-dark.svg \
 packaging/android/splash-light.svg \
 packaging/android/store-feature-graphic.png \


### PR DESCRIPTION
distribute_assets.sh now overwrites splash_dark.xml with the whitelabel splash_light.xml when no variant-specific dark splash exists, so that Q.HOME-CONTROL and Zewo-Dynamics no longer show the Consolinno splash in dark mode. Add it to restore_generated.sh so it can be reverted together with the other generated assets.