### PR TITLE
ESUI-1369: consume status-bar inset in CoHeader/ConsolinnoHeader/CoOverlay

### DIFF
--- a/components/CoHeader.qml
+++ b/components/CoHeader.qml
@@ -9,7 +9,7 @@ Item {
     // The header reaches the physical top edge of the screen. The interactive
     // band (back button, title, menu button) is shifted down by the system
     // status-bar / display-cutout inset so its content stays tappable while
-    // the blurred backdrop fills the area behind the status bar.
+    // the header background stays flush with the screen edge.
     property int safeAreaTop: SafeArea.margins.top
     implicitHeight: safeAreaTop + layout.implicitHeight + bottomBorder.height + 2 * Style.smallMargins
     property alias text: headline.text

--- a/components/CoHeader.qml
+++ b/components/CoHeader.qml
@@ -6,7 +6,12 @@ import Nymea
 
 Item {
     id: root
-    implicitHeight: layout.implicitHeight + bottomBorder.height + 2 * Style.mediumMargins
+    // The header reaches the physical top edge of the screen. The interactive
+    // band (back button, title, menu button) is shifted down by the system
+    // status-bar / display-cutout inset so its content stays tappable while
+    // the blurred backdrop fills the area behind the status bar.
+    property int safeAreaTop: SafeArea.margins.top
+    implicitHeight: safeAreaTop + layout.implicitHeight + bottomBorder.height + 2 * Style.mediumMargins
     property alias text: headline.text
     property alias subText: subHeadline.text
     property alias backButtonVisible: backButton.visible
@@ -84,7 +89,7 @@ Item {
             left: parent.left
             top: parent.top
             right: parent.right
-            topMargin: Style.mediumMargins
+            topMargin: root.safeAreaTop + Style.mediumMargins
             leftMargin: Style.smallMargins
             rightMargin: Style.margins
         }

--- a/components/CoOverlay.qml
+++ b/components/CoOverlay.qml
@@ -21,7 +21,10 @@ Dialog {
     topPadding: 0
     leftPadding: 0
     rightPadding: 0
-    bottomPadding: bg.radius
+    // Keep the visual rounding at the bottom while also reserving the
+    // navigation-bar inset so buttons inside the overlay's content don't sit
+    // under the gesture/navigation bar on Android edge-to-edge.
+    bottomPadding: bg.radius + SafeArea.margins.bottom
 
     enter: Transition {
         NumberAnimation {
@@ -47,7 +50,10 @@ Dialog {
         id: headerRect
         Layout.fillWidth: true
         color: Style.colors.menu_Header_Footer_Background
-        implicitHeight: headerLayout.implicitHeight
+        // Reserve room for the status-bar inset above the header content so the
+        // close button stays tappable when the overlay is opened over an
+        // Android edge-to-edge window.
+        implicitHeight: SafeArea.margins.top + headerLayout.implicitHeight
 
         layer.enabled: true
         layer.effect: OpacityMask {
@@ -56,7 +62,7 @@ Dialog {
 
         RowLayout {
             id: headerLayout
-            anchors.fill: parent
+            anchors { left: parent.left; right: parent.right; top: parent.top; topMargin: SafeArea.margins.top; bottom: parent.bottom }
             Layout.margins: 4
             spacing: Style.smallMargins
 

--- a/components/ConsolinnoHeader.qml
+++ b/components/ConsolinnoHeader.qml
@@ -11,8 +11,8 @@ import "../delegates"
 Item {
     id: root
     // System status-bar / display-cutout inset. The interactive row is
-    // shifted down by this amount so it stays tappable on Android 16+ where
-    // the window draws under the status bar.
+    // shifted down by this amount so it stays tappable on Android 16+ while
+    // the header background stays flush with the screen edge.
     property int safeAreaTop: SafeArea.margins.top
     implicitHeight: safeAreaTop + layout.implicitHeight + infoPane.height
     property string text

--- a/components/ConsolinnoHeader.qml
+++ b/components/ConsolinnoHeader.qml
@@ -10,7 +10,11 @@ import "../delegates"
 
 Item {
     id: root
-    implicitHeight: layout.implicitHeight + infoPane.height
+    // System status-bar / display-cutout inset. The interactive row is
+    // shifted down by this amount so it stays tappable on Android 16+ where
+    // the window draws under the status bar.
+    property int safeAreaTop: SafeArea.margins.top
+    implicitHeight: safeAreaTop + layout.implicitHeight + infoPane.height
     property string text
     property bool show_Image: false
     property alias backButtonVisible: backButton.visible
@@ -41,7 +45,7 @@ Item {
 
     RowLayout {
         id: layout
-        anchors { left: parent.left; top: parent.top; right: parent.right }
+        anchors { left: parent.left; top: parent.top; topMargin: root.safeAreaTop; right: parent.right }
 
         HeaderButton {
             id: menuButton


### PR DESCRIPTION
The window now draws edge-to-edge on Android 16+, so screen-edge chrome must reserve room for the system status bar / display cutout itself. CoHeader and ConsolinnoHeader grow their implicit height by SafeArea.margins.top and shift their inner RowLayout down by the same amount, so the blurred backdrop reaches the physical top of the screen while the back/menu buttons remain tappable. CoOverlay, which spans the full window when open, applies the same treatment to its header and adds SafeArea.margins.bottom to its bottom padding so content inside the overlay does not sit under the gesture/navigation bar.

On Android <= 15 and iOS without notch the inset is 0 and the headers keep their previous size.