### PR TITLE
ESUI-1485: Auto-scroll focused input into view when keyboard opens

### DIFF
--- a/devicepages/GenericConfigPage.qml
+++ b/devicepages/GenericConfigPage.qml
@@ -21,6 +21,34 @@ Item {
     signal backRequested()
 
     property int navigationFooterHeight: 0
+    property var _contentFlickable: null
+
+    function _findFlickable(item) {
+        if (!item) return null;
+        if (item.hasOwnProperty("contentY") && item.hasOwnProperty("contentItem"))
+            return item;
+        var kids = item.children || [];
+        for (var i = 0; i < kids.length; i++) {
+            var f = _findFlickable(kids[i]);
+            if (f) return f;
+        }
+        return null;
+    }
+
+    onHeightChanged: {
+        if (PlatformHelper.imeHeight <= 0) return;
+        var flickable = _contentFlickable;
+        if (!flickable) return;
+        var focused = Window.activeFocusItem;
+        if (!focused) return;
+        var itemPos = focused.mapToItem(flickable.contentItem, 0, focused.height);
+        var itemBottom = itemPos.y;
+        var usableHeight = flickable.height - root.navigationFooterHeight;
+        var visibleBottom = flickable.contentY + usableHeight;
+        if (itemBottom > visibleBottom) {
+            flickable.contentY = itemBottom - usableHeight + Style.margins;
+        }
+    }
 
     Rectangle {
         anchors.fill: parent
@@ -65,19 +93,9 @@ Item {
     }
 
     Component.onCompleted: {
-        function findFlickable(item) {
-            if (!item) return null;
-            if (item.hasOwnProperty("contentY") && item.hasOwnProperty("contentItem"))
-                return item;
-            var kids = item.children || [];
-            for (var i = 0; i < kids.length; i++) {
-                var f = findFlickable(kids[i]);
-                if (f) return f;
-            }
-            return null;
-        }
-        var c = findFlickable(content);
+        var c = _findFlickable(content);
         if (c) {
+            _contentFlickable = c;
             header.blurSource = c;
             c.topMargin = Qt.binding(function() { return header.height; });
             Qt.callLater(function() { c.contentY = -c.topMargin; });

--- a/optimization/BlackoutProtectionView.qml
+++ b/optimization/BlackoutProtectionView.qml
@@ -126,6 +126,19 @@ Page {
                        contentColumn.anchors.bottomMargin + root.navigationFooterHeight
         Component.onCompleted: Qt.callLater(() => contentY = -topMargin)
 
+        onHeightChanged: {
+            if (PlatformHelper.imeHeight <= 0) return;
+            var focused = Window.activeFocusItem;
+            if (!focused) return;
+            var itemPos = focused.mapToItem(contentColumn, 0, focused.height);
+            var itemBottom = itemPos.y;
+            var usableHeight = bodyFlickable.height - root.navigationFooterHeight;
+            var visibleBottom = bodyFlickable.contentY + usableHeight;
+            if (itemBottom > visibleBottom) {
+                bodyFlickable.contentY = itemBottom - usableHeight + Style.margins;
+            }
+        }
+
         ColumnLayout {
             id: contentColumn
             anchors { left: parent.left; right: parent.right; top: parent.top }

--- a/optimization/BlackoutProtectionView.qml
+++ b/optimization/BlackoutProtectionView.qml
@@ -130,7 +130,7 @@ Page {
             if (PlatformHelper.imeHeight <= 0) return;
             var focused = Window.activeFocusItem;
             if (!focused) return;
-            var itemPos = focused.mapToItem(contentColumn, 0, focused.height);
+            var itemPos = focused.mapToItem(bodyFlickable.contentItem, 0, focused.height);
             var itemBottom = itemPos.y;
             var usableHeight = bodyFlickable.height - root.navigationFooterHeight;
             var visibleBottom = bodyFlickable.contentY + usableHeight;

--- a/optimization/PVOptimization.qml
+++ b/optimization/PVOptimization.qml
@@ -138,6 +138,19 @@ Page {
 
         Component.onCompleted: Qt.callLater(() => contentY = -topMargin)
 
+        onHeightChanged: {
+            if (PlatformHelper.imeHeight <= 0) return;
+            var focused = Window.activeFocusItem;
+            if (!focused) return;
+            var itemPos = focused.mapToItem(contentColumn, 0, focused.height);
+            var itemBottom = itemPos.y;
+            var usableHeight = bodyFlickable.height - root.navigationFooterHeight;
+            var visibleBottom = bodyFlickable.contentY + usableHeight;
+            if (itemBottom > visibleBottom) {
+                bodyFlickable.contentY = itemBottom - usableHeight + Style.margins;
+            }
+        }
+
         ColumnLayout {
             id: contentColumn
             anchors { left: parent.left; right: parent.right; top: parent.top }

--- a/optimization/PVOptimization.qml
+++ b/optimization/PVOptimization.qml
@@ -142,7 +142,7 @@ Page {
             if (PlatformHelper.imeHeight <= 0) return;
             var focused = Window.activeFocusItem;
             if (!focused) return;
-            var itemPos = focused.mapToItem(contentColumn, 0, focused.height);
+            var itemPos = focused.mapToItem(bodyFlickable.contentItem, 0, focused.height);
             var itemBottom = itemPos.y;
             var usableHeight = bodyFlickable.height - root.navigationFooterHeight;
             var visibleBottom = bodyFlickable.contentY + usableHeight;

--- a/wizards/ConnectionWizard.qml
+++ b/wizards/ConnectionWizard.qml
@@ -741,10 +741,13 @@ ConsolinnoWizardPageBase {
                 clip: true
                 flickableDirection: Flickable.VerticalFlick
                 contentWidth: width
+                contentHeight: contentColumn.implicitHeight +
+                               contentColumn.anchors.topMargin +
+                               contentColumn.anchors.bottomMargin
 
                 ColumnLayout {
                     id: contentColumn
-                    anchors.fill: parent
+                    anchors { left: parent.left; right: parent.right; top: parent.top }
                     anchors.margins: Style.margins
                     anchors.topMargin: manualConnectionPage.headerHeight + Style.margins
                     anchors.bottomMargin: manualConnectionPage.navigationFooterHeight + Style.margins
@@ -809,12 +812,6 @@ ConsolinnoWizardPageBase {
                                 checked: true
                             }
                         }
-                    }
-
-                    Item {
-                        id: spacer
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
                     }
                 }
             }

--- a/wizards/ConnectionWizard.qml
+++ b/wizards/ConnectionWizard.qml
@@ -8,7 +8,6 @@ ConsolinnoWizardPageBase {
     id: root
 
     property Component navbarControls: welcomePageNavbarControls
-    property int navigationFooterHeight: 0
 
     headerLabel: qsTr("Setup %1").arg(Configuration.deviceName)
 
@@ -168,7 +167,6 @@ ConsolinnoWizardPageBase {
             id: licenseInfoPage
 
             property Component navbarControls: licenseInfoNavbarControls
-            property int navigationFooterHeight: 0
 
             headerLabel: qsTr("Setup %1").arg(Configuration.deviceName)
 
@@ -271,7 +269,6 @@ ConsolinnoWizardPageBase {
             id: privacyPolicyPage
 
             property Component navbarControls: privacyPolicyNavbarControls
-            property int navigationFooterHeight: 0
 
             headerLabel: qsTr("Setup %1").arg(Configuration.deviceName)
 
@@ -393,7 +390,6 @@ ConsolinnoWizardPageBase {
             id: networkConnectionInfoPage
 
             property Component navbarControls: networkConnectionInfoNavbarControls
-            property int navigationFooterHeight: 0
 
             headerLabel: qsTr("Setup %1").arg(Configuration.deviceName)
 
@@ -478,7 +474,6 @@ ConsolinnoWizardPageBase {
             id: discoverLeafletPage
 
             property Component navbarControls: discoverLeafletNavbarControls
-            property int navigationFooterHeight: 0
 
             headerLabel: qsTr("Setup %1").arg(Configuration.deviceName)
 
@@ -668,7 +663,6 @@ ConsolinnoWizardPageBase {
             id: manualConnectionPage
 
             property Component navbarControls: manualConnectionNavbarControls
-            property int navigationFooterHeight: 0
 
             headerLabel: qsTr("Setup %1").arg(Configuration.deviceName)
 

--- a/wizards/ConsolinnoWizardPageBase.qml
+++ b/wizards/ConsolinnoWizardPageBase.qml
@@ -14,6 +14,34 @@ Page {
     property string headerLabel: ""
     property real headerHeight: header.height
     property var backAction: function() { pageStack.pop() }
+    property int navigationFooterHeight: 0
+
+    onHeightChanged: {
+        if (PlatformHelper.imeHeight <= 0) return;
+        var focused = Window.activeFocusItem;
+        if (!focused) return;
+
+        // Walk up through parent chain to find a Flickable (duck-typed by contentY + flickableDirection)
+        var item = focused.parent;
+        var flickable = null;
+        while (item && item !== root) {
+            if ("contentY" in item && "flickableDirection" in item) {
+                flickable = item;
+                break;
+            }
+            item = item.parent;
+        }
+        if (!flickable) return;
+
+        var itemPos = focused.mapToItem(flickable.contentItem, 0, focused.height);
+        var itemBottom = itemPos.y;
+        var usableHeight = flickable.height - root.navigationFooterHeight;
+        var visibleBottom = flickable.contentY + usableHeight;
+
+        if (itemBottom > visibleBottom) {
+            flickable.contentY = itemBottom - usableHeight + Style.margins;
+        }
+    }
 
     header: null
     footer: null

--- a/wizards/InstallerDataView.qml
+++ b/wizards/InstallerDataView.qml
@@ -69,6 +69,19 @@ Page{
         contentHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin + root.navigationFooterHeight
         Component.onCompleted: Qt.callLater(() => contentY = -topMargin)
 
+        onHeightChanged: {
+            if (PlatformHelper.imeHeight <= 0) return;
+            var focused = Window.activeFocusItem;
+            if (!focused) return;
+            var itemPos = focused.mapToItem(layout, 0, focused.height);
+            var itemBottom = itemPos.y;
+            var usableHeight = bodyFlickable.height - root.navigationFooterHeight;
+            var visibleBottom = bodyFlickable.contentY + usableHeight;
+            if (itemBottom > visibleBottom) {
+                bodyFlickable.contentY = itemBottom - usableHeight + Style.margins;
+            }
+        }
+
         ColumnLayout {
             id: layout
             anchors { left: parent.left; right: parent.right; top: parent.top }


### PR DESCRIPTION
Add navigationFooterHeight property to ConsolinnoWizardPageBase and onHeightChanged handler that duck-types a Flickable child and scrolls the focused input field above the keyboard and navigation footer.

Remove now-redundant 'property int navigationFooterHeight: 0' declarations from all ConsolinnoWizardPageBase instances in ConnectionWizard.qml.